### PR TITLE
Fix publish.sh and deploy step to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 from setuptools import setup
 from setuputils import TestCoverageRatchetCommand, VerifyVersionCommand
 
-version = '0.5.0'
+__version__ = '0.5.1'
 setup(
     name='sqlalchemy-vertica-python',
-    version=version,
+    version=__version__,
     description='Vertica dialect for sqlalchemy using vertica_python',
     long_description=open("README.rst").read(),
     license="MIT",
     url='https://github.com/LocusEnergy/sqlalchemy-vertica-python',
-    download_url = 'https://github.com/LocusEnergy/sqlalchemy-vertica-python/tarball/{}'.format(version),
+    download_url = 'https://github.com/LocusEnergy/sqlalchemy-vertica-python/tarball/{}'.format(__version__),
     author='Locus Energy',
     author_email='dbio@locusenergy.com',
     packages=[


### PR DESCRIPTION
setuputils.py imports `__version__`, not `version`, which caused issues when running publish.sh and on deploy:

https://circleci.com/gh/bluelabsio/sqlalchemy-vertica-python/76