### PR TITLE
fix: make get_pk_constraint adhere to SqlAlchemy specs

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -372,12 +372,12 @@ class VerticaDialect(PGDialect):
             query += " AND table_schema = '" + schema + "' \n"
 
         cols = set()
-        name = set()
+        name = None
         for row in connection.execute(query):
-             name.add(row[1])
+             name = row[1] if name is None else name
              cols.add(row[2])
 
-        return {"constrained_columns": cols, "name": name}
+        return {"constrained_columns": list(cols), "name": name}
 
 
     def get_foreign_keys(self, connection, table_name, schema, **kw):


### PR DESCRIPTION
Currently `get_pk_constraint()` returns a dict that isn't in line with the SqlAlchemy specification. As stated in the [documentation](https://docs.sqlalchemy.org/en/13/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_pk_constraint), 

- `constrained_columns`: a list of column names that make up the primary key
- `name`: optional name of the primary key constraint.

I.e. the columns should be a list, and the name should be the name of the primary key if it exists.

This PR casts the list of columns into a list, and assigns the name based on the first non NULL value returned for the constraint name if defined.