### PR TITLE
Return schemas in order in get_schema_names()

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -161,7 +161,7 @@ class VerticaDialect(PGDialect):
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):
-        query = "SELECT schema_name FROM v_catalog.schemata"
+        query = "SELECT schema_name FROM v_catalog.schemata ORDER BY schema_name"
         rs = connection.execute(query)
         return [row[0] for row in rs if not row[0].startswith('v_')]
 


### PR DESCRIPTION
The previous order was the default order of the table (by schema_id),
which is not very useful
Ordering alphabetically makes more sense, and is what is being done in
other dialects