### PR TITLE
Deleted name of the VerticaDialect class

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -18,7 +18,6 @@ def use_identity(element, compiler, **kw):
 class VerticaDialect(PGDialect):
     """ Vertica Dialect using a vertica-python connection and PGDialect """
 
-    name = 'vertica'
     driver = 'vertica_python'
 
     # UPDATE functionality works with the following option set to False


### PR DESCRIPTION
Whenever you are trying to use Vertica with [alembic](https://github.com/sqlalchemy/alembic) it causes the issue:  https://stackoverflow.com/questions/55693215/error-when-init-vertica-as-a-database-backend-for-airflow
It happens because alembic doesn't have an implementation for dialect with name `vertica`. I believe if you keep `postgresql` it will be fine.

There are few reasons for doing this:
1. Allowing usage of Vertica as a metadata DB for Airflow and SuperSet. I know that this is not the best usage for analytical DB but still.
2. Allowing to migrate DB between environments using alembic. 
