### PR TITLE
Fix string type to remove deprecation warning for 3.8+

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -148,7 +148,7 @@ class VerticaDialect(PGDialect):
         v = connection.scalar("select version()")
         m = re.match(
             '.*Vertica Analytic Database '
-            'v(\d+)\.(\d+)\.(\d)+.*',
+            r'v(\d+)\.(\d+)\.(\d)+.*',
             v)
         if not m:
             raise AssertionError(


### PR DESCRIPTION
Example deprecation warning message:
```
DeprecationWarning: invalid escape sequence \d
    'v(\d+)\.(\d+)\.(\d)+.*',
```
Is there a way to add a test for this? 
Thanks