### PR TITLE
Create table issue when column name contains "SERIAL" in it.

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -12,7 +12,9 @@ from sqlalchemy.ext.compiler import compiles
 @compiles(CreateColumn, 'vertica')
 def use_identity(element, compiler, **kw):
     text = compiler.visit_create_column(element, **kw)
-    text = text.replace("SERIAL", "IDENTITY(1,1)")
+    ## if column name contains "SERIAL" then it was replaced with "IDENTITY(1,1)"
+    ## ex "LOT_SERIAL_NUMBER" was changed to  "LOT_IDENTITY(1,1)_NUMBER"
+    text = text.replace(" SERIAL", " IDENTITY(1,1)")
     return text
 
 


### PR DESCRIPTION
Pandas to_sql when create table which has a column name in which keyword "SERIAL" is present then it replaces the "SERIAL" in the column name with "IDENTITY(1,1)". Example "LOT_SERIAL_NUMBER" is changed to "LOT_IDENTITY(1,1)_NUMBER"

![image](https://github.com/bluelabsio/sqlalchemy-vertica-python/assets/29104616/29b14290-7abb-4461-a98c-24b74dd9a504)

![image](https://github.com/bluelabsio/sqlalchemy-vertica-python/assets/29104616/c103359f-6e1e-4e70-8b5b-7e81e176a989)

I have added a space in front of "SERIAL" in the replace function to resolve this issue.